### PR TITLE
Updates use of ll-baseball-card

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "polymer": "Polymer/polymer#^1.0.0"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.2.0",
+    "iron-component-page": "PolymerElements/iron-component-page#^1.1.7",
     "web-component-tester": "*"
   }
 }

--- a/ll-properties-dashboard.html
+++ b/ll-properties-dashboard.html
@@ -62,6 +62,18 @@ Example:
       }
     }
 
+    @media (min-width: 1800px) {
+      ll-baseball-card {
+        flex: 0 0 calc(25% - 2em);
+      }
+    }
+
+    @media (min-width: 2400px) {
+      ll-baseball-card {
+        flex: 0 0 calc(20% - 2em);
+      }
+    }
+
   </style>
 
   <style include="shared-styles"></style>

--- a/ll-properties-dashboard.html
+++ b/ll-properties-dashboard.html
@@ -48,6 +48,8 @@ Example:
     ll-baseball-card {
       flex: 0 0 calc(100% - 2em);
       margin: 1em;
+      white-space: nowrap;
+      overflow: hidden;
     }
 
     @media (min-width: 640px) {

--- a/ll-properties-dashboard.html
+++ b/ll-properties-dashboard.html
@@ -64,15 +64,21 @@ Example:
       }
     }
 
-    @media (min-width: 1800px) {
+    @media (min-width: 1300px) {
       ll-baseball-card {
         flex: 0 0 calc(25% - 2em);
       }
     }
 
-    @media (min-width: 2400px) {
+    @media (min-width: 1600px) {
       ll-baseball-card {
         flex: 0 0 calc(20% - 2em);
+      }
+    }
+
+    @media (min-width: 1800px) {
+      ll-baseball-card {
+        flex: 0 0 18em;
       }
     }
 

--- a/ll-properties-dashboard.html
+++ b/ll-properties-dashboard.html
@@ -41,12 +41,25 @@ Example:
     .grid {
       display: flex;
       flex-flow: row wrap;
-      justify-content: space-between;
+      justify-content: flex-start;
+      align-items: stretch;
     }
 
-    .grid > * {
-      flex: 1 1 12em;
+    ll-baseball-card {
+      flex: 0 0 calc(100% - 2em);
       margin: 1em;
+    }
+
+    @media (min-width: 640px) {
+      ll-baseball-card {
+        flex: 0 0 calc(50% - 2em);
+      }
+    }
+
+    @media (min-width: 1000px) {
+      ll-baseball-card {
+        flex: 0 0 calc(33.333% - 2em);
+      }
     }
 
   </style>

--- a/ll-properties-dashboard.html
+++ b/ll-properties-dashboard.html
@@ -38,6 +38,17 @@ Example:
       vertical-align: middle;
     }
 
+    .grid {
+      display: flex;
+      flex-flow: row wrap;
+      justify-content: space-between;
+    }
+
+    .grid > * {
+      flex: 1 1 12em;
+      margin: 1em;
+    }
+
   </style>
 
   <style include="shared-styles"></style>
@@ -61,16 +72,12 @@ Example:
     </div>
 
     <div class="row">
-      <div id="grid-view">
-        <div class="col-md-12">
+      <div id="grid-view" class="grid">
           <template is="dom-repeat" items="[[units]]" as="unit">
             <iron-ajax data-id$="{{unit.unitId}}" method="GET" on-response="_handleImageGet" on-error="_handleImageError" handle-as="json" ></iron-ajax>
-            <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
-              <ll-baseball-card data-id$="{{unit.unitId}}" image-id="{{unit.unitId}}" title="{{unit.name}}" >
-              </ll-baseball-card>
-            </div>
+            <ll-baseball-card data-id$="{{unit.unitId}}" image-id="{{unit.unitId}}" title="{{unit.name}}" image-aspect="0.75" >
+            </ll-baseball-card>
           </template>
-        </div>
       </div>
 
       <div id="list-view">


### PR DESCRIPTION
_This PR is dependent on https://github.com/LeisureLinkElements/ll-baseball-card/pull/4._
## This PR accomplishes the following:

It uses the new `imageAspect` property on `ll-baseball-card` to maintain consistent image size.
It also uses flexbox to create a grid of `ll-baseball-card`s
Break points are included at key sizes to increase the number of columns in the grid.
## To Test
- change directory to `ll-properties-dashboard`
- Pull down the `better-grid` branch from this repo
- `bower link`
- change directory to `integration-hub`
- `bower link ll-properties-dashboard`
- `npm run build:browser`
- test in browser for visual conformity
  - all cards in a row should have uniform heights regardless of how many lines the title may break across.
  - rows should be left aligned
  - cards should grow proportionally and smoothly until the next break point is met.
  - columns should increase from 1 - 5 as screen width increases from minimal to at least 2400px.
## This refactor accomplishes a number of things.
1. It simplifies the implementation details and improves the semantics of the ShadowDOM template.
2. It introduces a new property: `imageAspect` which enforces a fixed image aspect ratio.
3. It alters the style to be more subtle in its borders per blake using box-shadow over border.
